### PR TITLE
fix(deps): Allow ramsey/uuid v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,17 @@
   ],
   "require": {
     "php": "^7.2",
-    "roave/security-advisories": "dev-master",
-    "event-engine/php-persistence": "^0.8",
-    "event-engine/php-messaging": "^0.1",
     "event-engine/php-engine-utils": "^0.1",
+    "event-engine/php-messaging": "^0.1",
+    "event-engine/php-persistence": "^0.8",
     "prooph/event-store": "^7.0",
-    "ramsey/uuid" : "^3.6"
+    "roave/security-advisories": "dev-master"
   },
   "require-dev": {
+    "malukenho/docheader": "^0.1.4",
     "phpunit/phpunit": "^7.0",
     "prooph/php-cs-fixer-config": "^0.3",
-    "satooshi/php-coveralls": "^1.0",
-    "malukenho/docheader": "^0.1.4"
+    "satooshi/php-coveralls": "^1.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I've bumped the version constraint for `ramsey/uuid` to allow version 4.

Though, I'm not entirely sure this dependency is necessary as the package is not used within this package. Although it makes a call to `$message->uuid()->toString()` here: https://github.com/event-engine/prooph-v7-event-store/blob/f839884e9aae55f196b2ab71e93ce6f6c8cce39a/src/InMemoryEventStore.php#L466
this is handled via `prooph/common`. Should `ramsey/uuid` no longer be required in `prooph/common`, and no BC break was made in doing this, the installation of `ramsey/uuid` in this package would become redundant.